### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. Part of our GitHub Certifications program to help with college applications.",
+        "schedule": "Mondays and Wednesdays, 3:30 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Description
This PR adds the missing **GitHub Skills** activity that was announced by the principal in the school assembly.

## Changes
- Added "GitHub Skills" activity to the activities dictionary
- Set maximum capacity to 25 students
- Scheduled for Mondays and Wednesdays, 3:30 PM - 4:30 PM
- Description highlights the GitHub Certifications program for college applications

## Issue Resolved
Fixes #6 - 🚨 Missing Activity: GitHub Skills

This is time-sensitive as registrations close by the end of the week. Students can now sign up for this activity through the website.

## Testing
- ✅ Python syntax validated
- ✅ Activity appears in the activities list
- ✅ Students can now register for GitHub Skills

cc: @github-actions